### PR TITLE
Fixing bug with classpath not containing compiled endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ To have Swagger generate the OpenAPI specifications as part of the build add in 
           <resourcePackage>io.openapitools.swagger.example.alternate</resourcePackage>
         </resourcePackages>
       </configuration>
+      <executions>
+        <execution>
+          <goals>
+            <goal>generate</goal>
+          </goals>
+        </execution>
+      </executions>
     </plugin>
     ...
   </plugins>

--- a/src/main/java/io/openapitools/swagger/GenerateMojo.java
+++ b/src/main/java/io/openapitools/swagger/GenerateMojo.java
@@ -4,6 +4,9 @@ import io.swagger.v3.jaxrs2.Reader;
 import io.swagger.v3.oas.models.OpenAPI;
 import java.io.File;
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.Collections;
 import java.util.Set;
 
@@ -70,7 +73,10 @@ public class GenerateMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        Thread.currentThread().setContextClassLoader(createClassLoader());
+
         Reader reader = new Reader(swaggerConfig == null ? new OpenAPI() : swaggerConfig.createSwaggerModel());
+
 
         JaxRSScanner reflectiveScanner = new JaxRSScanner();
         if (resourcePackages != null && !resourcePackages.isEmpty()) {
@@ -95,6 +101,15 @@ public class GenerateMojo extends AbstractMojo {
                 throw new RuntimeException("Unable write " + outputFilename + " document", e);
             }
         });
+    }
+
+    private URLClassLoader createClassLoader() {
+        try {
+            File compiled = new File(project.getBuild().getOutputDirectory());
+            return new URLClassLoader(new URL[] {compiled.toURI().toURL()}, Thread.currentThread().getContextClassLoader());
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("Unable to create class loader with compiled classes", e);
+        }
     }
 
 }

--- a/src/test/java/io/openapitools/swagger/MavenProjectStub.java
+++ b/src/test/java/io/openapitools/swagger/MavenProjectStub.java
@@ -1,0 +1,13 @@
+package io.openapitools.swagger;
+
+import org.apache.maven.model.Build;
+
+public class MavenProjectStub extends org.apache.maven.plugin.testing.stubs.MavenProjectStub {
+
+    public MavenProjectStub() {
+        Build b = new Build();
+        b.setOutputDirectory("target/test-classes");
+        setBuild(b);
+    }
+
+}

--- a/src/test/resources/generate-mojo-defaults-pom.xml
+++ b/src/test/resources/generate-mojo-defaults-pom.xml
@@ -20,6 +20,8 @@
                         <resourcePackage>io.openapitools.swagger.example.alternate</resourcePackage>
                     </resourcePackages>
                     <outputDirectory>target/default</outputDirectory>
+
+                    <project implementation="io.openapitools.swagger.MavenProjectStub"/>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/test/resources/generate-mojo-full-nofilename-pom.xml
+++ b/src/test/resources/generate-mojo-full-nofilename-pom.xml
@@ -47,6 +47,8 @@
                     </outputFormats>
                     <outputDirectory>target/semifull</outputDirectory>
                     <outputFilename></outputFilename>
+
+                    <project implementation="io.openapitools.swagger.MavenProjectStub"/>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/test/resources/generate-mojo-full-pom.xml
+++ b/src/test/resources/generate-mojo-full-pom.xml
@@ -47,6 +47,8 @@
                     </outputFormats>
                     <outputDirectory>target/full</outputDirectory>
                     <outputFilename>open-api</outputFilename>
+
+                    <project implementation="io.openapitools.swagger.MavenProjectStub"/>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/test/resources/generate-mojo-pom.xml
+++ b/src/test/resources/generate-mojo-pom.xml
@@ -24,6 +24,8 @@
                     </outputFormats>
                     <outputDirectory>target/api</outputDirectory>
                     <outputFilename>swagger</outputFilename>
+
+                    <project implementation="io.openapitools.swagger.MavenProjectStub"/>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Fix for #5 and #6.

Compiled classes are now added to plugin classpath - furthermore the README was updated to correctly show how to add execution.