### PR TITLE
Add integration test to the Issue #25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,6 +269,8 @@
                             <execution>
                                 <id>integration-test</id>
                                 <goals>
+                                    <!-- install current plugin version into the IT repository first -->
+                                    <goal>install</goal>
                                     <goal>run</goal>
                                 </goals>
                             </execution>
@@ -292,7 +294,6 @@
                                 <goal>package</goal>
                             </goals>
                         </configuration>
-
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    
+
     <name>Swagger Maven Plugin</name>
     <groupId>io.openapitools.swagger</groupId>
     <version>2.1.1-SNAPSHOT</version>
@@ -14,8 +16,8 @@
 
     <licenses>
         <license>
-          <name>MIT License</name>
-          <url>http://www.opensource.org/licenses/mit-license.php</url>
+            <name>MIT License</name>
+            <url>http://www.opensource.org/licenses/mit-license.php</url>
         </license>
     </licenses>
 
@@ -33,7 +35,7 @@
         <connection>scm:git:https://github.com/openapi-tools/swagger-maven-plugin.git</connection>
         <developerConnection>scm:git:https://github.com/openapi-tools/swagger-maven-plugin.git</developerConnection>
         <url>https://github.com/openapi-tools/swagger-maven-plugin/tree/master</url>
-      <tag>HEAD</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>
@@ -63,6 +65,11 @@
         <org.apache.maven.plugin-testing.version>3.3.0</org.apache.maven.plugin-testing.version>
         <javax.xml.bin.jaxb-api.version>2.3.0</javax.xml.bin.jaxb-api.version>
         <javax.ws.rs.version>2.1</javax.ws.rs.version>
+
+        <groovy.version>1.8.0</groovy.version>
+        <groovy.eclipse.compiler.version>2.7.0-01</groovy.eclipse.compiler.version>
+        <groovy-eclipse-batch.version>2.0.4-04</groovy-eclipse-batch.version>
+        <openjpa.version>2.4.2</openjpa.version>
     </properties>
 
     <dependencies>
@@ -247,5 +254,76 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>run-its</id>
+            <build>
+                <defaultGoal>verify</defaultGoal>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-invoker-plugin</artifactId>
+                        <version>3.2.0</version>
+                        <executions>
+                            <execution>
+                                <id>integration-test</id>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <projectsDirectory>src/it</projectsDirectory>
+                            <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+                            <pomIncludes>
+                                <pomInclude>*/pom.xml</pomInclude>
+                            </pomIncludes>
+                            <postBuildHookScript>verify</postBuildHookScript>
+                            <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
+                            <settingsFile>src/it/settings.xml</settingsFile>
+                            <showErrors>true</showErrors>
+                            <streamLogs>false</streamLogs>
+                            <properties>
+                                <https.protocols>${https.protocols}</https.protocols>
+                            </properties>
+                            <goals>
+                                <goal>clean</goal>
+                                <goal>package</goal>
+                            </goals>
+                        </configuration>
+
+                    </plugin>
+                </plugins>
+            </build>
+            <!-- explicit dependencies so that they are downloaded to local repository -->
+            <!-- and subsequent runs are faster next time, as the artifacts will be taken from local -->
+            <dependencies>
+                <dependency>
+                    <groupId>org.codehaus.groovy</groupId>
+                    <artifactId>groovy-eclipse-compiler</artifactId>
+                    <version>${groovy.eclipse.compiler.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.codehaus.groovy</groupId>
+                    <artifactId>groovy-eclipse-batch</artifactId>
+                    <version>${groovy-eclipse-batch.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.codehaus.groovy</groupId>
+                    <artifactId>groovy-all</artifactId>
+                    <version>${groovy.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.openjpa</groupId>
+                    <artifactId>openjpa</artifactId>
+                    <version>${openjpa.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,6 @@
         <groovy.version>1.8.0</groovy.version>
         <groovy.eclipse.compiler.version>2.7.0-01</groovy.eclipse.compiler.version>
         <groovy-eclipse-batch.version>2.0.4-04</groovy-eclipse-batch.version>
-        <openjpa.version>2.4.2</openjpa.version>
     </properties>
 
     <dependencies>
@@ -317,11 +316,6 @@
                     <artifactId>groovy-all</artifactId>
                     <version>${groovy.version}</version>
                     <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.apache.openjpa</groupId>
-                    <artifactId>openjpa</artifactId>
-                    <version>${openjpa.version}</version>
                 </dependency>
             </dependencies>
         </profile>

--- a/src/it/ISSUE-25/invoker.properties
+++ b/src/it/ISSUE-25/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = clean package

--- a/src/it/ISSUE-25/pom.xml
+++ b/src/it/ISSUE-25/pom.xml
@@ -1,0 +1,68 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openapitools.swagger.it</groupId>
+    <artifactId>issue-25</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <description>IT that asserts that compile and runtime deps of project are correctly handled.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>javax</groupId>
+            <artifactId>javaee-api</artifactId>
+            <version>8.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-fileupload</groupId>
+            <artifactId>commons-fileupload</artifactId>
+            <version>1.4</version>
+        </dependency>
+    </dependencies>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.openapitools.swagger</groupId>
+                <artifactId>swagger-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <resourcePackages>
+                        <resourcePackage>foo</resourcePackage>
+                    </resourcePackages>
+                    <outputDirectory>${project.build.directory}</outputDirectory>
+                    <outputFilename>swagger</outputFilename>
+                    <outputFormats>JSON,YAML</outputFormats>
+                    <prettyPrint>true</prettyPrint>
+                    <useResourcePackagesChildren>true</useResourcePackagesChildren>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/it/ISSUE-25/pom.xml
+++ b/src/it/ISSUE-25/pom.xml
@@ -41,7 +41,6 @@
                     <outputFilename>swagger</outputFilename>
                     <outputFormats>JSON,YAML</outputFormats>
                     <prettyPrint>true</prettyPrint>
-                    <useResourcePackagesChildren>true</useResourcePackagesChildren>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/it/ISSUE-25/src/main/java/foo/Service.java
+++ b/src/it/ISSUE-25/src/main/java/foo/Service.java
@@ -1,0 +1,27 @@
+package foo;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+
+import org.apache.commons.fileupload.FileUploadException;
+
+@Path("/hello")
+public class Service {
+
+    @GET
+    @Path("/get")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    public List<String> get(@Context HttpServletRequest request) throws FileUploadException {
+        return Arrays.asList();
+    }
+
+}

--- a/src/it/ISSUE-25/src/main/resources/swagger-expected.json
+++ b/src/it/ISSUE-25/src/main/resources/swagger-expected.json
@@ -1,0 +1,25 @@
+{
+  "openapi" : "3.0.1",
+  "paths" : {
+    "/hello/get" : {
+      "get" : {
+        "operationId" : "get",
+        "responses" : {
+          "default" : {
+            "description" : "default response",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/it/ISSUE-25/src/main/resources/swagger-expected.yaml
+++ b/src/it/ISSUE-25/src/main/resources/swagger-expected.yaml
@@ -1,0 +1,14 @@
+openapi: 3.0.1
+paths:
+  /hello/get:
+    get:
+      operationId: get
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string

--- a/src/it/ISSUE-25/verify.bsh
+++ b/src/it/ISSUE-25/verify.bsh
@@ -1,0 +1,16 @@
+import java.io.*;
+import java.nio.*;
+import java.nio.file.*;
+import java.nio.charset.*;
+
+File expectedFile = new File(basedir, "target/classes/swagger-expected.json");
+String expected = new String(Files.readAllBytes(expectedFile.toPath()), StandardCharsets.UTF_8)
+    .replaceAll("\\r\\n?", "\n");
+
+File actualFile = new File(basedir, "target/swagger.json");
+String actual = new String(Files.readAllBytes(actualFile.toPath()), StandardCharsets.UTF_8)
+    .replaceAll("\\r\\n?", "\n");
+
+if (!expected.equals(actual)) {
+    throw new AssertionError("Swagger file does not match the expected one");
+}

--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings>
+    <profiles>
+        <profile>
+            <id>it-repo</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <repositories>
+                <repository>
+                    <id>local.central</id>
+                    <url>@localRepositoryUrl@</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>local.central</id>
+                    <url>@localRepositoryUrl@</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+    </profiles>
+</settings>

--- a/src/main/java/io/openapitools/swagger/GenerateMojo.java
+++ b/src/main/java/io/openapitools/swagger/GenerateMojo.java
@@ -112,32 +112,41 @@ public class GenerateMojo extends AbstractMojo {
             return;
         }
 
-        Thread.currentThread().setContextClassLoader(createClassLoader());
+        ClassLoader origClzLoader = Thread.currentThread().getContextClassLoader();
+        ClassLoader clzLoader = createClassLoader(origClzLoader);
+        
+        try {
+            // set the TCCL before everything else
+            Thread.currentThread().setContextClassLoader(clzLoader);
 
-        Reader reader = new Reader(swaggerConfig == null ? new OpenAPI() : swaggerConfig.createSwaggerModel());
+            Reader reader = new Reader(swaggerConfig == null ? new OpenAPI() : swaggerConfig.createSwaggerModel());
 
-        JaxRSScanner reflectiveScanner = new JaxRSScanner(getLog(), resourcePackages, useResourcePackagesChildren);
+            JaxRSScanner reflectiveScanner = new JaxRSScanner(getLog(), resourcePackages, useResourcePackagesChildren);
 
-        Application application = resolveApplication(reflectiveScanner);
-        reader.setApplication(application);
+            Application application = resolveApplication(reflectiveScanner);
+            reader.setApplication(application);
 
-        OpenAPI swagger = reader.read(reflectiveScanner.classes());
+            OpenAPI swagger = reader.read(reflectiveScanner.classes());
 
-        if (outputDirectory.mkdirs()) {
-            getLog().debug("Created output directory " + outputDirectory);
-        }
-
-        outputFormats.forEach(format -> {
-            try {
-                File outputFile = new File(outputDirectory, outputFilename + "." + format.name().toLowerCase());
-                format.write(swagger, outputFile, prettyPrint);
-                if (attachSwaggerArtifact) {
-                    projectHelper.attachArtifact(project, format.name().toLowerCase(), "swagger", outputFile);
-                }
-            } catch (IOException e) {
-                throw new RuntimeException("Unable write " + outputFilename + " document", e);
+            if (outputDirectory.mkdirs()) {
+                getLog().debug("Created output directory " + outputDirectory);
             }
-        });
+
+            outputFormats.forEach(format -> {
+                try {
+                    File outputFile = new File(outputDirectory, outputFilename + "." + format.name().toLowerCase());
+                    format.write(swagger, outputFile, prettyPrint);
+                    if (attachSwaggerArtifact) {
+                        projectHelper.attachArtifact(project, format.name().toLowerCase(), "swagger", outputFile);
+                    }
+                } catch (IOException e) {
+                    throw new RuntimeException("Unable write " + outputFilename + " document", e);
+                }
+            });
+        } finally {
+            // reset the TCCL back to the original class loader
+            Thread.currentThread().setContextClassLoader(origClzLoader);
+        }
     }
 
     private Application resolveApplication(JaxRSScanner reflectiveScanner) {
@@ -157,7 +166,7 @@ public class GenerateMojo extends AbstractMojo {
         return ClassUtils.createInstance(appClazz);
     }
 
-    private URLClassLoader createClassLoader() {
+    private URLClassLoader createClassLoader(ClassLoader parent) {
         try {
             Collection<String> dependencies = getDependentClasspathElements();
             URL[] urls = new URL[dependencies.size()];
@@ -165,7 +174,7 @@ public class GenerateMojo extends AbstractMojo {
             for (String dependency : dependencies) {
                 urls[index++] = Paths.get(dependency).toUri().toURL();
             }
-            return new URLClassLoader(urls, Thread.currentThread().getContextClassLoader());
+            return new URLClassLoader(urls, parent);
         } catch (MalformedURLException e) {
             throw new RuntimeException("Unable to create class loader with compiled classes", e);
         } catch (DependencyResolutionRequiredException e) {


### PR DESCRIPTION
This pull request adds the integration test to the problem fixed in  Issue #25.

As this problem heavily depends on maven classloading, ordinary IT is not an option for this case (at least I was not able to do it properly). Therefore, the integration test is performed by maven invoker plugin, which essentially takes a sample project and invokes specific maven goals on it (sample projects are located in stc/it, as this seems to be the maven invoker default option). The advantage is that the environment is exactly the same as with standard maven build.

The invoker ITs are only active if the "run-its" maven profile is activated. I did not alter your travis build in any way, so nothing should happen during the current travis build at this moment. 

This pull request is a side effect of my attempt to fix Issue #25, and I thought you might find it useful. If you would like to take it or adapt it somehow, the thing to do here is probably to adjust the travis build to activate the "run-its" profile.