### PR TITLE
fix hard coded default outputFilename

### DIFF
--- a/src/main/java/io/openapitools/swagger/GenerateMojo.java
+++ b/src/main/java/io/openapitools/swagger/GenerateMojo.java
@@ -132,7 +132,7 @@ public class GenerateMojo extends AbstractMojo {
                 File outputFile = new File(outputDirectory, outputFilename + "." + format.name().toLowerCase());
                 format.write(swagger, outputFile, prettyPrint);
                 if (attachSwaggerArtifact) {
-                    projectHelper.attachArtifact(project, format.name().toLowerCase(), "swagger", outputFile);
+                    projectHelper.attachArtifact(project, format.name().toLowerCase(), outputFilename, outputFile);
                 }
             } catch (IOException e) {
                 throw new RuntimeException("Unable write " + outputFilename + " document", e);


### PR DESCRIPTION
The filename of the generated spec was always swagger.json, regardless of the specified outputFilename. This is especially problematic when multiple maven-execution blocks are defined, then the generated files are overridden with only the last generated file remaining.