### PR TITLE
Fix sorting of #/components/schemas/*

### DIFF
--- a/src/main/java/io/openapitools/swagger/OpenAPISorter.java
+++ b/src/main/java/io/openapitools/swagger/OpenAPISorter.java
@@ -61,7 +61,7 @@ public class OpenAPISorter {
             return;
         }
 
-        sortSchemas(components.getSchemas());
+        components.setSchemas(sortSchemas(components.getSchemas()));
 
         components.setResponses(createSorted(components.getResponses()));
         components.setParameters(createSorted(components.getParameters()));

--- a/src/test/java/io/openapitools/swagger/OpenApiSorterTest.java
+++ b/src/test/java/io/openapitools/swagger/OpenApiSorterTest.java
@@ -22,12 +22,17 @@ public class OpenApiSorterTest {
 
     @Test
     public void testSort() {
-        ObjectSchema schema = new ObjectSchema();
-        schema.addProperties("s2", new StringSchema());
-        schema.addProperties("s1", new StringSchema());
+        ObjectSchema schema1 = new ObjectSchema();
+        schema1.addProperties("s1-2", new StringSchema());
+        schema1.addProperties("s1-1", new StringSchema());
+
+        ObjectSchema schema2 = new ObjectSchema();
+        schema2.addProperties("s2-2", new StringSchema());
+        schema2.addProperties("s2-1", new StringSchema());
 
         Components components = new Components()
-                .addSchemas("s1", schema)
+                .addSchemas("s2", schema2)
+                .addSchemas("s1", schema1)
                 .addResponses("k2", new ApiResponse())
                 .addResponses("k1", new ApiResponse())
                 .addParameters("k2", new Parameter())
@@ -55,9 +60,13 @@ public class OpenApiSorterTest {
 
         api = OpenAPISorter.sort(api);
 
-        assertEquals("s1", api.getComponents().getSchemas()
+        assertEquals("s1-1", api.getComponents().getSchemas()
                 .values().stream()
-                .findAny().get().getProperties()
+                .findFirst().get().getProperties()
+                .keySet().stream().findFirst().get());
+        assertEquals("s2-1", api.getComponents().getSchemas()
+                .values().stream()
+                .skip(1).findFirst().get().getProperties()
                 .keySet().stream().findFirst().get());
         assertEquals("k1", api.getComponents().getResponses().keySet().stream().findFirst().get());
         assertEquals("k1", api.getComponents().getParameters().keySet().stream().findFirst().get());


### PR DESCRIPTION
There was a regression in e629216a3e8be40f1f8f237f8a15756b36af9d82 that caused the result of `sortSchemas` not to be used.

This regression made schemas non sorted.

A test has been added and the fix has been done.