### PR TITLE
Bumping swagger core version to 1.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         
-        <io.swagger.version>1.5.16</io.swagger.version>
+        <io.swagger.version>1.6.2</io.swagger.version>
         <junit.version>4.12</junit.version>
         <org.mockito.version>2.11.0</org.mockito.version>
         <org.slf4j.version>1.7.25</org.slf4j.version>


### PR DESCRIPTION
1.6.2 is the latest in the 1.5 branch of swagger.

I compared the json and yaml files created by the tests with core version 1.5.16 and 1.6.2, and the only thing different was in yaml files:
```
responses:
        200:
          description: "successful operation"
          schema:
            $ref: "#/definitions/AccountRepresentation"
        404:
          description: "No account found."
```
became
```
responses:
        "200":
          description: "successful operation"
          schema:
            $ref: "#/definitions/AccountRepresentation"
        "404":
          description: "No account found."
```
So the response codes gained quotes with this change.

I was looking into adding the vendor extensions to the swagger-maven-plugin, and those require updating the swagger core to at least 1.5.17, so why not try to upgrade all the way.