### PR TITLE
feat: replace reflections lib with classgraph

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
         <groovy.version>1.8.0</groovy.version>
         <groovy.eclipse.compiler.version>2.7.0-01</groovy.eclipse.compiler.version>
         <groovy-eclipse-batch.version>2.0.4-04</groovy-eclipse-batch.version>
+        <io.github.classgraph.version>4.8.149</io.github.classgraph.version>
         <io.openapitools.jackson.dataformat.version>1.0.8</io.openapitools.jackson.dataformat.version>
         <io.swagger.core.v3.version>2.1.7</io.swagger.core.v3.version>
         <javax.xml.bin.jaxb-api.version>2.3.0</javax.xml.bin.jaxb-api.version>
@@ -64,7 +65,6 @@
         <org.apache.maven.version>3.6.0</org.apache.maven.version>
         <org.apache.maven.plugin-testing.version>3.3.0</org.apache.maven.plugin-testing.version>
         <org.mockito.version>3.2.0</org.mockito.version>
-        <org.reflections.version>0.9.12</org.reflections.version>
         <org.slf4j.version>1.7.29</org.slf4j.version>
     </properties>
 
@@ -105,9 +105,9 @@
             <version>${org.apache.maven.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.reflections</groupId>
-            <artifactId>reflections</artifactId>
-            <version>${org.reflections.version}</version>
+            <groupId>io.github.classgraph</groupId>
+            <artifactId>classgraph</artifactId>
+            <version>${io.github.classgraph.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.xml.bind</groupId>

--- a/src/main/java/io/openapitools/swagger/JaxRSScanner.java
+++ b/src/main/java/io/openapitools/swagger/JaxRSScanner.java
@@ -2,6 +2,7 @@ package io.openapitools.swagger;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -10,12 +11,11 @@ import javax.ws.rs.Path;
 import javax.ws.rs.core.Application;
 
 import org.apache.maven.plugin.logging.Log;
-import org.reflections.Reflections;
-import org.reflections.scanners.ResourcesScanner;
-import org.reflections.scanners.SubTypesScanner;
-import org.reflections.scanners.TypeAnnotationsScanner;
-import org.reflections.util.ConfigurationBuilder;
 
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ClassInfo;
+import io.github.classgraph.ClassInfoList;
+import io.github.classgraph.ScanResult;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 
 /**
@@ -33,46 +33,41 @@ class JaxRSScanner {
     public JaxRSScanner(Log log, Set<String> resourcePackages, Boolean useResourcePackagesChildren) {
         this.log = log;
         this.resourcePackages = resourcePackages == null ? Collections.emptySet() : new HashSet<>(resourcePackages);
-        this.useResourcePackagesChildren = useResourcePackagesChildren != null && useResourcePackagesChildren;
+        this.useResourcePackagesChildren = Boolean.TRUE.equals(useResourcePackagesChildren);
     }
 
     Application applicationInstance() {
-        ConfigurationBuilder config = ConfigurationBuilder
-                .build(resourcePackages)
-                .setScanners(new ResourcesScanner(), new TypeAnnotationsScanner(), new SubTypesScanner());
-        Reflections reflections = new Reflections(config);
-        Set<Class<? extends Application>> applicationClasses = reflections.getSubTypesOf(Application.class)
-                .stream()
-                .filter(this::filterClassByResourcePackages)
-                .collect(Collectors.toSet());
-        if (applicationClasses.isEmpty()) {
-            return null;
+        ClassGraph classGraph = new ClassGraph().enableClassInfo();
+        try (ScanResult scanResult = classGraph.scan()) {
+            List<ClassInfo> applicationClasses = scanResult.getSubclasses(Application.class.getName()).stream()
+                    .filter(this::filterClassByResourcePackages)
+                    .collect(Collectors.toList());
+            if (applicationClasses.size() == 1) {
+                return ClassUtils.createInstance(applicationClasses.get(0).loadClass(Application.class));
+            }
+            if (applicationClasses.size() > 1) {
+                log.warn("More than one javax.ws.rs.core.Application classes found on the classpath, skipping");
+            }
         }
-        if (applicationClasses.size() > 1) {
-            log.warn("More than one javax.ws.rs.core.Application classes found on the classpath, skipping");
-            return null;
-        }
-        return ClassUtils.createInstance(applicationClasses.iterator().next());
+        return null;
     }
 
     Set<Class<?>> classes() {
-        ConfigurationBuilder config = ConfigurationBuilder
-                .build(resourcePackages)
-                .setScanners(new ResourcesScanner(), new TypeAnnotationsScanner(), new SubTypesScanner());
-        Reflections reflections = new Reflections(config);
-        Stream<Class<?>> apiClasses = reflections.getTypesAnnotatedWith(Path.class)
-                .stream()
-                .filter(this::filterClassByResourcePackages);
-        Stream<Class<?>> defClasses = reflections.getTypesAnnotatedWith(OpenAPIDefinition.class)
-                .stream()
-                .filter(this::filterClassByResourcePackages);
-        return Stream.concat(apiClasses, defClasses).collect(Collectors.toSet());
+        ClassGraph classGraph = new ClassGraph().enableClassInfo().enableAnnotationInfo();
+        try (ScanResult scanResult = classGraph.scan()) {
+            ClassInfoList apiClasses = scanResult.getClassesWithAnnotation(Path.class.getName());
+            ClassInfoList defClasses = scanResult.getClassesWithAnnotation(OpenAPIDefinition.class.getName());
+            return Stream.concat(apiClasses.stream(), defClasses.stream())
+                    .filter(this::filterClassByResourcePackages)
+                    .map(ClassInfo::loadClass)
+                    .collect(Collectors.toSet());
+        }
     }
 
-    private boolean filterClassByResourcePackages(Class<?> cls) {
+    private boolean filterClassByResourcePackages(ClassInfo cls) {
         return resourcePackages.isEmpty()
-                || resourcePackages.contains(cls.getPackage().getName())
-                || (useResourcePackagesChildren && resourcePackages.stream().anyMatch(p -> cls.getPackage().getName().startsWith(p)));
+                || resourcePackages.contains(cls.getPackageName())
+                || (useResourcePackagesChildren && resourcePackages.stream().anyMatch(p -> cls.getPackageName().startsWith(p)));
     }
 
 }


### PR DESCRIPTION
The `reflections` library is no longer maintained. There is no point in employing workarounds to the "SubTypesScanner not found issue" (for reference, one would have to build the `reflections` differently like [here](https://github.com/victools/jsonschema-generator/pull/223/files#diff-99aa8443f7535bdd052fa3a6e0f6ecba1325b54dfdf6af8c2f20899a416351a7L228-R240)).

Instead, do the same as other libraries do: move to `classgraph` instead.
It's faster, still being maintained, and doesn't have this annoying bug.
Extra upside: no need to change the context classloader. `classgraph` has a more explicit classloader handling than `reflections`.

This fixes #96.